### PR TITLE
Enable tls / ssl for execution node rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,8 +92,10 @@ dependencies = [
  "futures-io",
  "futures-util",
  "log",
+ "native-tls",
  "pin-project-lite 0.2.9",
  "tokio 1.25.0",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -684,6 +686,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio 1.25.0",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tracing",
@@ -2549,6 +2552,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha1",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 axum = "0.6"
 anyhow = "1"
 async-trait = "0.1"
-async-tungstenite = { version = "0.19", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.19", features = ["tokio-native-tls"] }
 bytes = "1"
 cached = "0.42"
 chrono = { version = "0.4", features = ["serde"] }
@@ -52,6 +52,7 @@ tracing-subscriber = { version = "0.3", features = [
   "json",
   "std",
 ] }
+tokio-native-tls = "0.3.0"
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3

--- a/src/execution_chain/node/mod.rs
+++ b/src/execution_chain/node/mod.rs
@@ -88,7 +88,15 @@ impl IdPool {
     }
 }
 
-type NodeMessageRx = SplitStream<WebSocketStream<TokioAdapter<TcpStream>>>;
+type NodeMessageRx = SplitStream<
+    WebSocketStream<
+        async_tungstenite::stream::Stream<
+            TokioAdapter<TcpStream>,
+            TokioAdapter<tokio_native_tls::TlsStream<tokio::net::TcpStream>>,
+        >,
+    >,
+>;
+
 type MessageHandlersShared =
     Arc<Mutex<HashMap<u16, oneshot::Sender<Result<serde_json::Value, RpcError>>>>>;
 type IdPoolShared = Arc<Mutex<IdPool>>;
@@ -140,7 +148,15 @@ async fn handle_messages(
 pub struct ExecutionNode {
     id_pool: Arc<Mutex<IdPool>>,
     message_handlers: MessageHandlersShared,
-    message_sink: SplitSink<WebSocketStream<TokioAdapter<TcpStream>>, Message>,
+    message_sink: SplitSink<
+        WebSocketStream<
+            async_tungstenite::stream::Stream<
+                TokioAdapter<TcpStream>,
+                TokioAdapter<tokio_native_tls::TlsStream<tokio::net::TcpStream>>,
+            >,
+        >,
+        Message,
+    >,
 }
 
 impl ExecutionNode {


### PR DESCRIPTION
I was trying to run a local instance of the server using a remote rpc api (Alchemy, Infura, Chainstack etc.) as execution node.
Since most remote rpc api  providers require tls/ssl encryption I encountered  `Url(TlsFeatureNotEnabled)` error when entering the `wss://...` url as `GETH_URL` value.

This PR should fix this and allow people to run the server tests etc. without having to run a whole execution node on their local machine. 

NOTE: 
While I was able to run all tests with `GETH_URL` set to both `Alchemy` and `Chainstack` rpc urls, I was not able to actually check for backwards compatibility (unencrypted websocket connection) since I do not have the resources to run a local node and don't know of any node provider that allows connecting without tls/ssl encryption.